### PR TITLE
fix: 서버 사이드 fetch 시 localhost 하드코딩 제거 및 환경변수 처리

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,7 @@
 import type { NextConfig } from 'next';
+import createNextIntlPlugin from 'next-intl/plugin';
 
-const createNextIntlPlugin = require('next-intl/plugin');
 const withNextIntl = createNextIntlPlugin();
-
 const nextConfig: NextConfig = {
   webpack(config) {
     config.module.rules.push({

--- a/src/constants/apiEndPoint.ts
+++ b/src/constants/apiEndPoint.ts
@@ -1,4 +1,6 @@
-export const baseUrl = `${process.env.API_URL}/api`;
+import { API_URL } from '@/lib/notion/config';
+
+export const baseUrl = `${API_URL}/api`;
 
 export const METHOD = {
   GET: 'get',

--- a/src/lib/notion/config.ts
+++ b/src/lib/notion/config.ts
@@ -1,13 +1,7 @@
 // Common
 export const LOCALE_ID = process.env.LOCALE || '';
-export const API_URL = process.env.API_URL || '';
+export const API_URL = process.env.NEXT_PUBLIC_SITE_URL;
+
 // Notion
 export const NOTION_API_KEY = process.env.NOTION_API_KEY || '';
 export const NOTION_DB_GNB_ID = process.env.NOTION_DB_GNB_ID || '';
-
-if (!NOTION_API_KEY) {
-  throw new Error('NOTION_API_KEY is not defined in environment variables');
-}
-if (!NOTION_DB_GNB_ID) {
-  throw new Error('NOTION_DB_GNB_ID is not defined in environment variables');
-}


### PR DESCRIPTION
- 서버 환경에서 상대경로 fetch 시 'Failed to parse URL' 에러 발생
- API 호출 시 localhost:3000 하드코딩을 제거하고 NEXT_PUBLIC_SITE_URL 환경변수 기반으로 처리
- 로컬에서는 .env.local, Vercel에서는 환경변수 설정을 통해 대응